### PR TITLE
Add `self_execute` option

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -1,6 +1,10 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  push:
+    branches:
+      - main
+      - develop
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Add a `self_execute` option to open/modify/close position functions. When the option is set to `True` it will call a function to:
* Wait for transaction receipt
* Wait 15 second delay
* Estimate gas for the `executeOrder` transaction
* If successful, execute the order
* If reverts, wait 1 second and try again