### PR TITLE
Add sub-directories to package setup

### DIFF
--- a/module/setup.py
+++ b/module/setup.py
@@ -5,7 +5,15 @@ setup(
     description='Python SDK for Kwenta',
     long_description='Python SDK for Kwenta',
     author='Kwenta DAO',
-    packages=['kwenta'],
+    packages=[
+        'kwenta',
+        'kwenta.alerts',
+        'kwenta.cli',
+        'kwenta.contracts',
+        'kwenta.contracts.json',
+        'kwenta.pyth',
+        'kwenta.queries'
+    ],
     install_requires=[
         "numpy",
         "pandas",


### PR DESCRIPTION
This PR adds subdirectories of the `module/kwenta` to the setup, to ensure that they are included in the build.